### PR TITLE
Including <functional> in include/feature_data.hpp

### DIFF
--- a/include/feature_data.hpp
+++ b/include/feature_data.hpp
@@ -1,6 +1,7 @@
 #ifndef FEATURE_DATA_H
 #define FEATURE_DATA_H
 
+#include <functional>
 #include "art.hpp"
 #include "cmn_data.hpp"
 #include "room.hpp"


### PR DESCRIPTION
ia didn't compile on my computer (Archlinux 64 bit, g++ (GCC) 4.9.2 20150304, sdl2 2.0.3-1). The error was that std::function was being used without including <functional>. This change allows me to compile and run ia.