### PR TITLE
Fixed off-by-one error in array index in map_parse::expand.

### DIFF
--- a/src/map_parsing.cpp
+++ b/src/map_parsing.cpp
@@ -355,8 +355,8 @@ void expand(const bool in[MAP_W][MAP_H], bool out[MAP_W][MAP_H],
 
     const int X0 = max(0,     area_allowed_to_modify.p0.x);
     const int Y0 = max(0,     area_allowed_to_modify.p0.y);
-    const int X1 = min(MAP_W, area_allowed_to_modify.p1.x);
-    const int Y1 = min(MAP_H, area_allowed_to_modify.p1.y);
+    const int X1 = min(MAP_W - 1, area_allowed_to_modify.p1.x);
+    const int Y1 = min(MAP_H - 1, area_allowed_to_modify.p1.y);
 
     for (int x = X0; x <= X1; ++x)
     {


### PR DESCRIPTION
Prior to this change it was possible that `X1` be the same as `MAP_W` which would allow `x` to become `MAP_W` and go out of bound. This fixed a common seg fault I was getting when descending stairs.