### PR TITLE
Fixed error where properties are not removed when armor is destroyed.

### DIFF
--- a/include/item.hpp
+++ b/include/item.hpp
@@ -175,6 +175,11 @@ public:
         return armor_points() <= 0;
     }
 
+    virtual void on_destroy(Actor& actor)
+    {
+        on_unequip_hook(actor);
+    }
+
     std::string armor_data_line(const bool WITH_BRACKETS) const;
 
     int take_dur_hit_and_get_reduced_dmg(const int DMG_BEFORE);

--- a/src/actor.cpp
+++ b/src/actor.cpp
@@ -637,7 +637,7 @@ Actor_died Actor::hit(int dmg, const Dmg_type dmg_type, Dmg_method method)
                         armor->name(Item_ref_type::plain, Item_ref_inf::none);
                     msg_log::add("My " + armor_name + " is torn apart!", clr_msg_note);
                 }
-
+                armor->on_destroy(*this);
                 delete armor;
                 armor = nullptr;
                 inv_->slots_[int(Slot_id::body)].item = nullptr;


### PR DESCRIPTION
Not the best solution, but an useable solution. My preferred solution would be to change it so items (or just armor) knows who its owner is, and the removal of properties on destruction could be handled by the destructor.